### PR TITLE
Improve build process and display outcome

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+^CONTRIBUTING\.md$

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aecfeedr
 
+[![Build Status](https://travis-ci.org/tobiasziegler/aecfeedr.svg?branch=develop)](https://travis-ci.org/tobiasziegler/aecfeedr)
+
 ## Overview
 
 `aecfeedr` is an R package for accessing and reading information from the Australian Electoral Commission's (AEC) FTP media feeds.


### PR DESCRIPTION
These changes just remove `CONTRIBUTING.md` from the package build to prevent a note, and add a build status badge to the README.