### PR TITLE
Fix the parameter order for `xml_find_text`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aecfeedr
 Title: Retrieve Australian Federal Election Information and Results
-Version: 0.1.0.9005
+Version: 0.1.0.9006
 Authors@R: person("David", "Mallard",
                email = "correspondence@davidmallard.id.au",
                role = c("aut", "cre"))

--- a/R/xml.R
+++ b/R/xml.R
@@ -62,7 +62,6 @@ xml_find_attr <- function(x, xpath, attr, ns = xml_ns(x)) {
 #'
 #' @param x A document, node or node set
 #' @param xpath A string containing a xpath (1.0) expression
-#' @param trim If `TRUE` will trim leading and trailiing spaces
 #' @param ns Optionally, a named vector giving prefix-url pairs, as produced
 #'   by [xml_ns()]. If provided, all names will be explicitly
 #'   qualified with the ns prefix, i.e. if the element `bar` is defined
@@ -70,6 +69,7 @@ xml_find_attr <- function(x, xpath, attr, ns = xml_ns(x)) {
 #'   similarly for attributes). Default namespaces must be given an explicit
 #'   name. The ns is ignored when using [xml_name<-()] and
 #'   [xml_set_name()].
+#' @param trim If `TRUE` will trim leading and trailiing spaces
 #'
 #' @return A character vector.
 #' @export
@@ -77,7 +77,7 @@ xml_find_attr <- function(x, xpath, attr, ns = xml_ns(x)) {
 #' @examples
 #' x <- xml2::read_xml("<a>foo</a>")
 #' xml_find_text(x, "/a")
-xml_find_text <- function(x, xpath, trim = FALSE, ns = xml_ns(x)) {
+xml_find_text <- function(x, xpath, ns = xml_ns(x), trim = FALSE) {
   xml_text(
     xml_find_first(x, xpath, ns),
     trim

--- a/man/xml_find_text.Rd
+++ b/man/xml_find_text.Rd
@@ -4,14 +4,12 @@
 \alias{xml_find_text}
 \title{Extract the text from the first node that matches an xpath expression}
 \usage{
-xml_find_text(x, xpath, trim = FALSE, ns = xml_ns(x))
+xml_find_text(x, xpath, ns = xml_ns(x), trim = FALSE)
 }
 \arguments{
 \item{x}{A document, node or node set}
 
 \item{xpath}{A string containing a xpath (1.0) expression}
-
-\item{trim}{If \code{TRUE} will trim leading and trailiing spaces}
 
 \item{ns}{Optionally, a named vector giving prefix-url pairs, as produced
 by \code{\link[=xml_ns]{xml_ns()}}. If provided, all names will be explicitly
@@ -20,6 +18,8 @@ in namespace \code{foo}, it will be called \code{foo:bar}. (And
 similarly for attributes). Default namespaces must be given an explicit
 name. The ns is ignored when using \code{\link[=xml_name<-]{xml_name<-()}} and
 \code{\link[=xml_set_name]{xml_set_name()}}.}
+
+\item{trim}{If \code{TRUE} will trim leading and trailiing spaces}
 }
 \value{
 A character vector.


### PR DESCRIPTION
The three parameters to be passed to `xml_find_first` should come first, including the optional `ns` parameter, and then the optional `trim` parameter for `xml_text`.

This makes better logical sense, but the other order also creates a risk that any code passing a cached namespace variable in as the third argument without naming it (and leaving `trim` unspecified to use its default value) will see the XPath searches executed without passing in the namespaces - meaning they will again parse the namespaces on row of data that is being processed. I accidentally did this in a branch I'm working on and it caused a fivefold increase in the time taken to process a results file.